### PR TITLE
18821341  dropdown hidden behind soft keyboard IOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.6",
+  "version": "2.5.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.1",
+  "version": "2.5.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.3",
+  "version": "2.5.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.4.0",
+  "version": "2.5.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.7",
+  "version": "2.5.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.0",
+  "version": "2.5.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3309,17 +3309,6 @@
             "unique-filename": "^1.1.1"
           }
         },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -3381,18 +3370,6 @@
           "requires": {
             "merge-stream": "^2.0.0",
             "supports-color": "^7.0.0"
-          }
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
           }
         },
         "locate-path": {
@@ -3483,18 +3460,6 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.5.0",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.5.0.tgz",
-          "integrity": "sha512-WXh+7AgFxGTgb5QAkQtFeUcHNIEq3PGVQ8WskY5ZiFbWBkOwcCPRs4w/2tVyTbh2q6TVRlO3xfvIukUtjsu62A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -15357,6 +15322,87 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.8.3",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+      "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.8",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.4",
+  "version": "2.5.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.3",
+  "version": "2.5.0-beta.4",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.0",
+  "version": "2.5.0-beta.1",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.4.0",
+  "version": "2.5.0-beta.0",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.1",
+  "version": "2.5.0-beta.2",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.4",
+  "version": "2.5.0-beta.6",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.7",
+  "version": "2.5.0-beta.8",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.6",
+  "version": "2.5.0-beta.7",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0-beta.8",
+  "version": "2.5.0",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -115,7 +115,10 @@
     </div>
     <div class="row">
       <div style="text-align:center">
-        long list and soft keyboard (test on IOS) <br>
+        long list and soft keyboard (test on IOS and software keyboard) <br>
+        <button v-if="isLargePage === false" @click="isLargePage = true">Large Page</button>
+        <button v-if="isLargePage === true" @click="isLargePage = false">Small Page</button>
+        <br>
         <input
           type="text"
           v-dropdown-directive.bottom.center="{
@@ -123,11 +126,48 @@
             arrow: false,
             scrollableContentClassName: 'dropdown-list',
             isReady: true,
+            preventPageScrolling: true
           }"
         >
         <div
           ref="customDropdown"
           dropdown-id="text-input-dropdown-long-list"
+          class="dropdown"
+        >
+          <div class="dropdown-list">
+            <div
+              v-for="(item, index) in ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5', 'Item 6', 'Item 7', 'Item 8', 'Item 9', 'Item 10', 'Item 11', 'Item 12']"
+              class="dropdown-list__item"
+              :key="index"
+              @click="() => $refs.customDropdown.close()"
+            >
+              {{ item }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div v-bind:class="{ large_page: isLargePage }">
+        &nbsp;
+      </div>
+    </div>
+    <div class="row">
+      <div style="text-align:center">
+        long list and soft keyboard - bootom of page (test on IOS and software keyboard) <br>
+        <input
+          type="text"
+          v-dropdown-directive.bottom.center="{
+            id: 'text-input-dropdown-long-list-bottom',
+            arrow: false,
+            scrollableContentClassName: 'dropdown-list',
+            isReady: true,
+            preventPageScrolling: true
+          }"
+        >
+        <div
+          ref="customDropdown"
+          dropdown-id="text-input-dropdown-long-list-bottom"
           class="dropdown"
         >
           <div class="dropdown-list">
@@ -154,10 +194,19 @@ export default {
   directives: {
     DropdownDirective,
   },
+  data: () => ({
+    isLargePage: true,
+  }),
 };
 </script>
 
 <style>
+html, body {
+  margin: 0;
+  position: relative;
+  min-height: 100vh;
+}
+
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -210,5 +259,11 @@ button {
 input[type='text'],
 textarea {
   font-size: 16px; /* prevents zoom windows on focus ios */
+}
+
+.large_page {
+  height: 1800px;
+  background-color: #6b87e4;
+  width: 100%;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -116,8 +116,18 @@
     <div class="row">
       <div style="text-align:center">
         long list and soft keyboard (test on IOS and software keyboard) <br>
-        <button v-if="isLargePage === false" @click="isLargePage = true">Large Page</button>
-        <button v-if="isLargePage === true" @click="isLargePage = false">Small Page</button>
+        <button
+          v-if="isLargePage === false"
+          @click="isLargePage = true"
+        >
+          Large Page
+        </button>
+        <button
+          v-if="isLargePage === true"
+          @click="isLargePage = false"
+        >
+          Small Page
+        </button>
         <br>
         <input
           type="text"
@@ -148,7 +158,7 @@
       </div>
     </div>
     <div class="row">
-      <div v-bind:class="{ large_page: isLargePage }">
+      <div :class="{ large_page: isLargePage }">
         &nbsp;
       </div>
     </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,6 +62,7 @@
           arrow: true,
           scrollableContentClassName: 'dropdown-list',
           isReady: true,
+          touchCloseButton: true
         }"
       >
         Trigger
@@ -91,6 +92,7 @@
           arrow: true,
           scrollableContentClassName: 'dropdown-list',
           isReady: true,
+          touchCloseButton: true
         }"
       >
         Trigger
@@ -113,6 +115,38 @@
         </div>
       </div>
     </div>
+
+    <div class="row">
+      <div
+        v-dropdown-directive.bottom.center="{
+          id: 'text-trigger-dropdown-2',
+          arrow: true,
+          scrollableContentClassName: 'dropdown-list',
+          isReady: true,
+          touchCloseButton: true
+        }"
+      >
+        Trigger touch close button
+      </div>
+      <div
+        ref="customDropdown"
+        dropdown-id="text-trigger-dropdown-2"
+        class="dropdown"
+      >
+        <input type="text">
+        <div class="dropdown-list">
+          <div
+            v-for="(item, index) in ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5', 'Item 6', 'Item 7', 'Item 8', 'Item 9', 'Item 10', 'Item 12', 'Item 13', 'Item 14', 'Item 15', 'Item 16', 'Item 17', 'Item 18', 'Item 19', 'Item 20', 'Item 21', 'Item 22', 'Item 23', 'Item 24', 'Item 25', 'Item 26', 'Item 27', 'Item 28', 'Item 29', 'Item 30']"
+            class="dropdown-list__item"
+            :key="index"
+            @click="() => $refs.customDropdown.close()"
+          >
+            {{ item }}
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="row">
       <div style="text-align:center">
         long list and soft keyboard (test on IOS and software keyboard) <br>
@@ -169,7 +203,7 @@
           type="text"
           v-dropdown-directive.bottom.center="{
             id: 'text-input-dropdown-long-list-bottom',
-            arrow: false,
+            arrow: true,
             scrollableContentClassName: 'dropdown-list',
             isReady: true,
             preventPageScrolling: true

--- a/src/App.vue
+++ b/src/App.vue
@@ -113,6 +113,36 @@
         </div>
       </div>
     </div>
+    <div class="row">
+      <div style="text-align:center">
+        long list and soft keyboard (test on IOS) <br>
+        <input
+          type="text"
+          v-dropdown-directive.bottom.center="{
+            id: 'text-input-dropdown-long-list',
+            arrow: false,
+            scrollableContentClassName: 'dropdown-list',
+            isReady: true,
+          }"
+        >
+        <div
+          ref="customDropdown"
+          dropdown-id="text-input-dropdown-long-list"
+          class="dropdown"
+        >
+          <div class="dropdown-list">
+            <div
+              v-for="(item, index) in ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5', 'Item 6', 'Item 7', 'Item 8', 'Item 9', 'Item 10', 'Item 11', 'Item 12']"
+              class="dropdown-list__item"
+              :key="index"
+              @click="() => $refs.customDropdown.close()"
+            >
+              {{ item }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -175,5 +205,10 @@ button {
 
 .dropdown-list__item:hover {
   background-color: #f5f7fa;
+}
+
+input[type='text'],
+textarea {
+  font-size: 16px; /* prevents zoom windows on focus ios */
 }
 </style>

--- a/src/Dropdown.directive.js
+++ b/src/Dropdown.directive.js
@@ -128,7 +128,10 @@ const detachListeners = (temporaryHideAllDropdownsRef) => {
 };
 
 const openDropdown = ({
-  dropdown, arrow, backgroundMask, scrollableContentClassName, preventPageScrollingClassName,
+  dropdown,
+  arrow,
+  backgroundMask,
+  scrollableContentClassName,
 }, {
   offset,
   collocation,
@@ -136,6 +139,7 @@ const openDropdown = ({
   onOpen,
   keepOthersOpen,
   temporaryHideAllDropdownsRef,
+  preventPageScrolling,
 }, trigger) => {
   if (!keepOthersOpen) { dropdown.closeOthers?.(); }
   const isDropdownOpen = dropdown.getAttribute('open') === 'true';
@@ -151,11 +155,7 @@ const openDropdown = ({
     document.body.appendChild(arrow.element);
     arrow.element.style.display = 'block';
   }
-  console.log('preventPageScrollingClassName', preventPageScrollingClassName);
-  if (preventPageScrollingClassName && hasTouchSupport) {
-    disableScrolling(document.querySelector(`.${preventPageScrollingClassName}`));
-    disableScrolling(document.querySelector(`body`));
-  }
+  if (preventPageScrolling && hasTouchSupport) disableScrolling(document.body);
   const isCollocated = collocateElementAt({
     trigger,
     element: dropdown,
@@ -170,17 +170,18 @@ const openDropdown = ({
   onOpen?.();
 };
 
-const closeDropdown = (
-  {dropdown, arrow, backgroundMask, preventPageScrollingClassName,},
-  { onClose, temporaryHideAllDropdownsRef },
-  keepListenersAttached
-) => {
+const closeDropdown = ({
+  dropdown,
+  arrow,
+  backgroundMask,
+}, {
+  onClose,
+  temporaryHideAllDropdownsRef,
+  preventPageScrolling,
+}, keepListenersAttached) => {
   const isDropdownOpen = dropdown.getAttribute('open') === 'true';
   if (!isDropdownOpen) { return; }
-  if (preventPageScrollingClassName && hasTouchSupport) {
-    restoreScrolling(document.querySelector(`.${preventPageScrollingClassName}`));
-    restoreScrolling(document.querySelector(`body`));
-  }
+  if (preventPageScrolling && hasTouchSupport) restoreScrolling(document.body);
   if (backgroundMask.element) {
     backgroundMask.element.parentNode.removeChild(backgroundMask.element);
     backgroundMask.element.style.display = 'none';
@@ -264,7 +265,7 @@ const mountDropdown = (trigger, value = {}, nativeModifiers) => {
     modifiers,
     scrollableContentClassName,
     otherScrollableContentClassNames = [],
-    preventPageScrollingClassName,
+    preventPageScrolling,
     arrow,
     arrowColor = '#fff',
     zIndex = 9999,
@@ -288,7 +289,6 @@ const mountDropdown = (trigger, value = {}, nativeModifiers) => {
     arrow: arrow ? initArrow(id, arrowColor, zIndex) : {},
     backgroundMask: hasTouchSupport ? initBackgroundMask(id, zIndex) : {},
     scrollableContentClassName,
-    preventPageScrollingClassName,
   };
   const debounceDelayInMilliseconds = 500;
   const debouncedTemporaryHideAllDropdowns = debounce(openTemporaryClosedDropdowns, debounceDelayInMilliseconds);
@@ -312,6 +312,7 @@ const mountDropdown = (trigger, value = {}, nativeModifiers) => {
       keepDropdownsOpenOnUIEvent,
       id,
     ),
+    preventPageScrolling,
   };
   trigger.click = (event) => onTriggerClick(event, trigger, dropdownElementsSet, extra);
   dropdown.open = () => openDropdown(dropdownElementsSet, extra, trigger);

--- a/src/Dropdown.directive.js
+++ b/src/Dropdown.directive.js
@@ -168,10 +168,6 @@ const closeDropdown = ({
 }, keepListenersAttached) => {
   const isDropdownOpen = dropdown.getAttribute('open') === 'true';
   if (!isDropdownOpen) { return; }
-  if (dropdown.onVieportChangeInterval) {
-    clearInterval(dropdown.onVieportChangeInterval);
-    dropdown.onVieportChangeInterval = null;
-  }
   if (backgroundMask.element) {
     backgroundMask.element.parentNode.removeChild(backgroundMask.element);
     backgroundMask.element.style.display = 'none';

--- a/src/Dropdown.directive.js
+++ b/src/Dropdown.directive.js
@@ -7,6 +7,16 @@ import {
 
 const hasTouchSupport = ('ontouchstart' in document.documentElement);
 
+const disableScrolling = (element) => {
+  if (!element || !element.style) { return; }
+  element.style.overflow = 'hidden';
+};
+
+const restoreScrolling = (element) => {
+  if (!element || !element.style) { return; }
+  element.style.overflow = '';
+};
+
 const moveElementFromOriginalPlaceToBodyRoot = (element) => {
   const hasElementMoved = element.getAttribute('has-element-moved') === 'true';
   if (!element || !element.id || hasElementMoved) { return; }
@@ -118,7 +128,7 @@ const detachListeners = (temporaryHideAllDropdownsRef) => {
 };
 
 const openDropdown = ({
-  dropdown, arrow, backgroundMask, scrollableContentClassName,
+  dropdown, arrow, backgroundMask, scrollableContentClassName, preventPageScrollingClassName,
 }, {
   offset,
   collocation,
@@ -141,6 +151,11 @@ const openDropdown = ({
     document.body.appendChild(arrow.element);
     arrow.element.style.display = 'block';
   }
+  console.log('preventPageScrollingClassName', preventPageScrollingClassName);
+  if (preventPageScrollingClassName && hasTouchSupport) {
+    disableScrolling(document.querySelector(`.${preventPageScrollingClassName}`));
+    disableScrolling(document.querySelector(`body`));
+  }
   const isCollocated = collocateElementAt({
     trigger,
     element: dropdown,
@@ -155,9 +170,17 @@ const openDropdown = ({
   onOpen?.();
 };
 
-const closeDropdown = ({ dropdown, arrow, backgroundMask }, { onClose, temporaryHideAllDropdownsRef }, keepListenersAttached) => {
+const closeDropdown = (
+  {dropdown, arrow, backgroundMask, preventPageScrollingClassName,},
+  { onClose, temporaryHideAllDropdownsRef },
+  keepListenersAttached
+) => {
   const isDropdownOpen = dropdown.getAttribute('open') === 'true';
   if (!isDropdownOpen) { return; }
+  if (preventPageScrollingClassName && hasTouchSupport) {
+    restoreScrolling(document.querySelector(`.${preventPageScrollingClassName}`));
+    restoreScrolling(document.querySelector(`body`));
+  }
   if (backgroundMask.element) {
     backgroundMask.element.parentNode.removeChild(backgroundMask.element);
     backgroundMask.element.style.display = 'none';
@@ -241,6 +264,7 @@ const mountDropdown = (trigger, value = {}, nativeModifiers) => {
     modifiers,
     scrollableContentClassName,
     otherScrollableContentClassNames = [],
+    preventPageScrollingClassName,
     arrow,
     arrowColor = '#fff',
     zIndex = 9999,
@@ -264,6 +288,7 @@ const mountDropdown = (trigger, value = {}, nativeModifiers) => {
     arrow: arrow ? initArrow(id, arrowColor, zIndex) : {},
     backgroundMask: hasTouchSupport ? initBackgroundMask(id, zIndex) : {},
     scrollableContentClassName,
+    preventPageScrollingClassName,
   };
   const debounceDelayInMilliseconds = 500;
   const debouncedTemporaryHideAllDropdowns = debounce(openTemporaryClosedDropdowns, debounceDelayInMilliseconds);

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -470,6 +470,11 @@ const resetElementContentHeight = (element) => {
   element.style.height = 'auto';
 };
 
+const resetElementContentMaxHeight = (element) => {
+  if (!element || !element.style) { return; }
+  element.style.maxHeight = '';
+};
+
 const applyTresholdToCoordinates = (coordinates, viewport) => {
   const newCoordinates = { ...coordinates };
   const verticalTreshold = getThresholdInPixels(viewport.height);
@@ -564,13 +569,14 @@ const getRequestedCollocation = (modifiers = {}, defaultPosition = 'bottom', def
   }
 };
 
-const applyTouchElementContentHeight = (element, elementContent) => {
+const applyTouchElementContentMaxHeight = (element, elementContent) => {
   if (!element || !elementContent) return;
   const elementRect = element.getBoundingClientRect();
   const contentExtraHeight = getContentExtraHeight(element, elementContent);
   const dropdownHeight = elementRect.height;
   const contentHeight = dropdownHeight - contentExtraHeight;
-  applyOverflowToElementContent(elementContent, contentHeight);
+  elementContent.style.maxHeight = `${contentHeight}px`;
+  elementContent.style.overflowY = 'auto';
 };
 
 const applyTouchElementCentering = (element) => {
@@ -609,9 +615,9 @@ const applyInitialTouchElementStyle = (element) => {
 
 const touchCollocateElemeAt = (element, elementContent) => {
   applyTouchElementCentering(element);
-  resetElementContentHeight(elementContent);
+  resetElementContentMaxHeight(elementContent);
   setTimeout(() => {
-    applyTouchElementContentHeight(element, elementContent);
+    applyTouchElementContentMaxHeight(element, elementContent);
   }, 0);
 };
 

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -81,6 +81,19 @@ const areWindowsDimesionsEqual = (w1, w2) => (
   && w1.visualOffsetTop === w2.visualOffsetTop
 );
 
+const getElementDimensions = (element) => {
+  if (!element) { return { width: 0, height: 0 }; }
+  return {
+    width: element.offsetWidth,
+    height: element.offsetHeight,
+  };
+};
+
+const areElementDimesionsEqual = (e1, e2) => (
+  e1.width === e2.width
+  && e1.height === e2.height
+);
+
 const isDropdownOpen = (element) => element?.getAttribute('open') === 'true';
 
 // TODO: replace getElementContentExtraHeight by getContentExtraHeight and remove. (requires extensive testing for non touch devices)
@@ -713,6 +726,7 @@ const touchDetectViewportChangesAndCollocate = (element, elementContent, element
   touchCollocateElemeAt(element, elementContent, touchCloseButton, computedElementDimensions);
   disableTouchScroll(elementPreventTouchScroll);
   let previousWindowsDimensions = getWindowDimensions();
+  let previousElementDimensions = getElementDimensions(element);
 
   const resizeOnViewportChange = () => {
     if (!isDropdownOpen(element)) {
@@ -730,13 +744,16 @@ const touchDetectViewportChangesAndCollocate = (element, elementContent, element
     }
 
     const currentWindowsDimensions = getWindowDimensions();
+    const currentElementDimensions = getElementDimensions(element);
     const hasWindowChanged = !areWindowsDimesionsEqual(previousWindowsDimensions, currentWindowsDimensions);
     if (hasWindowChanged) {
       console.log('hasWindowChanged', hasWindowChanged);
       touchCollocateElemeAt(element, elementContent, touchCloseButton, computedElementDimensions);
       previousWindowsDimensions = currentWindowsDimensions;
-    } else if (shouldDisplayCloseButton(element, touchCloseButton)) {
+    } else if (shouldDisplayCloseButton(element, touchCloseButton) || !areElementDimesionsEqual(previousElementDimensions, currentElementDimensions)) {
+      console.log('hasElementChanged', !areElementDimesionsEqual(previousElementDimensions, currentElementDimensions));
       applyTouchElementCentering(element, touchCloseButton);
+      previousElementDimensions = currentElementDimensions;
     }
   };
 

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -696,7 +696,7 @@ const applyTouchElementStyle = (element, touchCloseButton, computedElementDimens
   applyTouchElementCentering(element, touchCloseButton);
 };
 
-const touchCollocateElemeAt = (element, elementContent, touchCloseButton, computedElementDimensions) => {
+const touchCollocateElementAt = (element, elementContent, touchCloseButton, computedElementDimensions) => {
   applyTouchElementStyle(element, touchCloseButton, computedElementDimensions);
   resetElementMaxHeight(elementContent);
   setTimeout(() => {
@@ -712,7 +712,7 @@ const touchDetectViewportChangesAndCollocate = (element, elementContent, element
   let viewportChangeIntervalID;
   // gets dimesion set by css or inline previous to any handling of the modal
   const computedElementDimensions = getComputedElementMaxDimensions(element);
-  touchCollocateElemeAt(element, elementContent, touchCloseButton, computedElementDimensions);
+  touchCollocateElementAt(element, elementContent, touchCloseButton, computedElementDimensions);
   disableTouchScroll(elementPreventTouchScroll);
   let previousWindowsDimensions = getWindowDimensions();
   let previousElementDimensions = getElementDimensions(element);
@@ -735,7 +735,7 @@ const touchDetectViewportChangesAndCollocate = (element, elementContent, element
     const currentElementDimensions = getElementDimensions(element);
     const hasWindowChanged = !areWindowsDimesionsEqual(previousWindowsDimensions, currentWindowsDimensions);
     if (hasWindowChanged) {
-      touchCollocateElemeAt(element, elementContent, touchCloseButton, computedElementDimensions);
+      touchCollocateElementAt(element, elementContent, touchCloseButton, computedElementDimensions);
       previousWindowsDimensions = currentWindowsDimensions;
     } else if (shouldDisplayCloseButton(element, touchCloseButton) || !areElementDimesionsEqual(previousElementDimensions, currentElementDimensions)) {
       applyTouchElementCentering(element, touchCloseButton);

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -660,25 +660,18 @@ const applyTouchElementCentering = (element, touchCloseButton) => {
   const viewport = getViewPort();
   const elementRect = element.getBoundingClientRect();
   isTouchDropdownFullHeight(element, elementRect);
-  console.log('viewport', viewport);
-  console.log('elementRect', elementRect);
 
   const top = window.scrollY + (viewport.height / 2);
   const negativeMarginY = elementRect.height / 2;
-  console.log('top', top);
-  console.log('negativeMarginY', negativeMarginY);
   element.style.top = `${top}px`;
   element.style.marginTop = `-${negativeMarginY}px`;
 
   const left = window.scrollX + (viewport.width / 2);
   const negativeMarginX = elementRect.width / 2;
-  console.log('left', left);
-  console.log('negativeMarginX', negativeMarginX);
   element.style.left = `${left}px`;
   element.style.marginLeft = `-${negativeMarginX}px`;
 
   if (touchCloseButton && isTouchDropdownFullHeight(element)) {
-    console.log('touchCloseButton', touchCloseButton);
     touchCloseButton.style.top = `${top}px`;
     touchCloseButton.style.marginTop = `-${negativeMarginY + 15}px`;
     element.style.marginTop = `-${negativeMarginY - 15}px`;
@@ -690,16 +683,13 @@ const applyTouchElementCentering = (element, touchCloseButton) => {
 
 const applyTouchElementStyle = (element, touchCloseButton, computedElementDimensions) => {
   const viewport = getViewPort();
-  console.log('applyTouchElementStyle computed', computedElementDimensions);
 
   const maxAvailableViewportHeight = viewport.height - (maxTouchVerticalThresholdInPixels * 2);
   const maxAvailableHeight = Math.min(maxAvailableViewportHeight, computedElementDimensions.maxHeight);
-  console.log('maxAvailableHeight', maxAvailableHeight);
   element.style.maxHeight = `${maxAvailableHeight}px`;
 
   const maxAvailableViewportWidth = viewport.width - (maxTouchHorizontalThresholdInPixels * 2);
   const maxAvailableWidth = Math.min(maxAvailableViewportWidth, computedElementDimensions.maxWidth, maxTouchElementWidthInPixels);
-  console.log('maxAvailableWidth', maxAvailableWidth);
   element.style.maxWidth = `${maxAvailableWidth}px`;
   element.style.width = `${maxAvailableWidth}px`;
 
@@ -710,7 +700,6 @@ const touchCollocateElemeAt = (element, elementContent, touchCloseButton, comput
   applyTouchElementStyle(element, touchCloseButton, computedElementDimensions);
   resetElementMaxHeight(elementContent);
   setTimeout(() => {
-    console.log('elementRect 2', element.getBoundingClientRect());
     applyTouchElementContentMaxHeight(element, elementContent);
   }, 0);
 };
@@ -730,7 +719,6 @@ const touchDetectViewportChangesAndCollocate = (element, elementContent, element
 
   const resizeOnViewportChange = () => {
     if (!isDropdownOpen(element)) {
-      console.trace('dropdown been closed', viewportChangeIntervalID);
       resetTouchElementStyle(element);
       resetTouchScroll(elementPreventTouchScroll);
       clearInterval(viewportChangeInterval);
@@ -747,11 +735,9 @@ const touchDetectViewportChangesAndCollocate = (element, elementContent, element
     const currentElementDimensions = getElementDimensions(element);
     const hasWindowChanged = !areWindowsDimesionsEqual(previousWindowsDimensions, currentWindowsDimensions);
     if (hasWindowChanged) {
-      console.log('hasWindowChanged', hasWindowChanged);
       touchCollocateElemeAt(element, elementContent, touchCloseButton, computedElementDimensions);
       previousWindowsDimensions = currentWindowsDimensions;
     } else if (shouldDisplayCloseButton(element, touchCloseButton) || !areElementDimesionsEqual(previousElementDimensions, currentElementDimensions)) {
-      console.log('hasElementChanged', !areElementDimesionsEqual(previousElementDimensions, currentElementDimensions));
       applyTouchElementCentering(element, touchCloseButton);
       previousElementDimensions = currentElementDimensions;
     }
@@ -762,7 +748,6 @@ const touchDetectViewportChangesAndCollocate = (element, elementContent, element
   viewportChangeInterval = setInterval(resizeOnViewportChange, onViewportChangeIntervalInMs);
   viewportChangeIntervalID = `${viewportChangeInterval}`;
   element.viewportChangeIntervalID = viewportChangeIntervalID;
-  console.trace('touch device', viewportChangeIntervalID);
 };
 
 const collocateElementAt = ({

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -575,7 +575,7 @@ const touchCollocateElemeAt = (element, elementContent, trigger, arrow) => {
   applyTouchScreensCoordinates(element, elementContent, { ...touchScreensElementCoordinates });
 };
 
-/* New version of IOS does not trigger any event when the viewport changes due to soft keyboar
+/* New version of IOS does not trigger any event when the viewport changes due to soft keyboard
  * so we need to use an interval to detect changes.
  * onViewportChangeInterval should be dismissed when the dorpdown is closed */
 const touchDetectViewportChangesAndCollocate = (element, elementContent, trigger, arrow) => {

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -24,6 +24,8 @@ const deviceMaxViewport = {
   height: window.visualViewport?.height || window.innerHeight,
 };
 
+const isPortrait = (deviceSice) => (deviceSice.height >= deviceSice.width);
+
 const updateDeviceViewport = () => {
   console.log('updateDeviceViewport');
   const newDeviceViewport = {
@@ -38,9 +40,7 @@ const updateDeviceViewport = () => {
     deviceMaxViewport.width = Math.max(deviceMaxViewport.width, newDeviceViewport.width);
     deviceMaxViewport.height = Math.max(deviceMaxViewport.height, newDeviceViewport.height);
   }
-}
-
-const isPortrait = (deviceSice) => (deviceSice.height >= deviceSice.width);
+};
 
 const addScrollXOffset = (data) => (data + window.pageXOffset);
 
@@ -330,7 +330,6 @@ const mapCoordinatesToCenterPosition = ({
   console.log('contentHeight', elementCoordinates.contentHeight);
   console.log('bottom', elementCoordinates.bottom);
   if (hiddenVieportHeight > 1) {
-    //elementCoordinates.contentHeight -= hiddenVieportHeight;
     elementCoordinates.bottom += hiddenVieportHeight;
     console.log('contentHeight modified', elementCoordinates.contentHeight);
     console.log('bottom modified', elementCoordinates.bottom);
@@ -464,6 +463,12 @@ const resetElementContentHeight = (element) => {
   element.style.height = 'auto';
 };
 
+const resetAndHideElement = (element) => {
+  if (!element || !element.style) { return; }
+  resetElementPosition(element);
+  element.style.opacity = '0';
+};
+
 const applyTouchScreensCoordinates = (element, elementContent, coordinates, shouldReset) => {
   if (!element || !element.style) { return; }
   if (shouldReset) resetAndHideElement(element);
@@ -478,12 +483,6 @@ const applyTouchScreensCoordinates = (element, elementContent, coordinates, shou
     element.style.opacity = '';
     applyOverflowToElementContent(elementContent, coordinates.contentHeight);
   }, 500);
-};
-
-const resetAndHideElement = (element) => {
-  if (!element || !element.style) { return; }
-  resetElementPosition(element);
-  element.style.opacity = '0';
 };
 
 const applyTresholdToCoordinates = (coordinates, viewport) => {

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -154,24 +154,9 @@ const getViePort = () => ({
 
 const applyTouchCoordinatesCorrection = (elementCoordinates) => {
   if (!window.visualViewport) return;
-  console.log('window.innerHeight', window.innerHeight);
-  console.log('visualViewport.height', visualViewport?.height);
-  console.log('visualViewport.offsetTop', visualViewport.offsetTop);
-  console.log('hiddenHeight', window.innerHeight - visualViewport.height);
-  console.log('scrollY', window.scrollY);
-
   elementCoordinates.top += window.scrollY;
   const totalHeight = document.body.offsetHeight;
   elementCoordinates.bottom = totalHeight - window.scrollY - visualViewport.height + maxThresholdInPixels;
-
-  console.log('bootom', elementCoordinates.bottom);
-  console.log('timestamp', Date.now());
-  console.log('--------------------------------------------');
-
-  // const hiddenHeight = window.innerHeight - visualViewport.height;
-  // if (hiddenHeight > 1) {
-  //   elementCoordinates.bottom += hiddenHeight;
-  // }
 };
 
 const mapCoordinatesToTopPosition = ({

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -577,7 +577,7 @@ const touchCollocateElemeAt = (element, elementContent, trigger, arrow) => {
 
 /* New version of IOS does not trigger any event when the viewport changes due to soft keyboard
  * so we need to use an interval to detect changes.
- * onViewportChangeInterval should be dismissed when the dorpdown is closed */
+ * onViewportChangeInterval should be dismissed when the dropdown is closed */
 const touchDetectViewportChangesAndCollocate = (element, elementContent, trigger, arrow) => {
   const getWindowDimensions = () => ({
     winHeight: window.innerHeight,

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -632,26 +632,6 @@ const isTouchDropdownFullHeight = (element, rect) => {
 
 const shouldDisplayCloseButton = (element, touchCloseButton) => !isTouchCloseButtonDisplayed(touchCloseButton) && isTouchDropdownFullHeight(element);
 
-const isTouchElementOutOfLimits = (element, shouldLog) => {
-  if (!element) { return false; }
-  const viewport = getViewPort();
-  const elementRect = element.getBoundingClientRect();
-  const topLimit = window.scrollY;
-  const bottomLimit = window.scrollY + viewport.height;
-  const isOutLimitsTop = elementRect.top < topLimit;
-  const isOutLimitsBottom = elementRect.bottom > bottomLimit;
-  if (shouldLog) {
-    const x = {
-      topLimit,
-      bottomLimit,
-      top: elementRect.top,
-      bottom: elementRect.bottom,
-    };
-    console.log('isTouchElementOutOfLimits', x);
-  }
-  return isOutLimitsTop || isOutLimitsBottom;
-};
-
 const applyTouchElementContentMaxHeight = (element, elementContent) => {
   if (!element || !elementContent) return;
   const elementRect = element.getBoundingClientRect();
@@ -751,11 +731,8 @@ const touchDetectViewportChangesAndCollocate = (element, elementContent, element
 
     const currentWindowsDimensions = getWindowDimensions();
     const hasWindowChanged = !areWindowsDimesionsEqual(previousWindowsDimensions, currentWindowsDimensions);
-    const isOutOflimits = isTouchElementOutOfLimits(element); // checks if the modal is badly positioned
     if (hasWindowChanged) {
       console.log('hasWindowChanged', hasWindowChanged);
-      console.log('isOutOflimits', isOutOflimits);
-      isTouchElementOutOfLimits(element, true);
       touchCollocateElemeAt(element, elementContent, touchCloseButton, computedElementDimensions);
       previousWindowsDimensions = currentWindowsDimensions;
     } else if (shouldDisplayCloseButton(element, touchCloseButton)) {

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -156,7 +156,7 @@ const applyTouchCoordinatesCorrection = (elementCoordinates) => {
   if (!window.visualViewport) return;
   elementCoordinates.top += window.scrollY;
   const totalHeight = document.body.offsetHeight;
-  elementCoordinates.bottom = totalHeight - window.scrollY - visualViewport.height + maxThresholdInPixels;
+  elementCoordinates.bottom = totalHeight - window.scrollY - window.visualViewport.height + maxThresholdInPixels;
 };
 
 const mapCoordinatesToTopPosition = ({
@@ -581,8 +581,8 @@ const touchCollocateElemeAt = (element, elementContent, trigger, arrow) => {
 const touchDetectVieportChangesAndCollocate = (element, elementContent, trigger, arrow) => {
   const getState = () => ({
     winHeight: window.innerHeight,
-    visualHeight: visualViewport?.height || 0,
-    visualOffsetTop: visualViewport?.offsetTop || 0,
+    visualHeight: window.visualViewport?.height || 0,
+    visualOffsetTop: window.visualViewport?.offsetTop || 0,
   });
   const isSameEstate = (e1, e2) => (
     e1.winHeight === e2.winHeight
@@ -599,9 +599,7 @@ const touchDetectVieportChangesAndCollocate = (element, elementContent, trigger,
     }
   };
 
-  // first render should be triggered before firs interval
-  const firstrenderDelay = onVieportChangeIntervalMs - 1;
-  touchCollocateElemeAt(element, elementContent, trigger, arrow, firstrenderDelay);
+  touchCollocateElemeAt(element, elementContent, trigger, arrow);
   element.onVieportChangeInterval = setInterval(resizeOnVieportChange, onVieportChangeIntervalMs);
 };
 

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -19,7 +19,7 @@ const maxThresholdInPercentage = 5;
 
 const minContentHeightInPixels = 150;
 
-const onVieportChangeIntervalMs = 500;
+const onViewportChangeIntervalInMs = 500;
 
 const hasTouchSupport = ('ontouchstart' in document.documentElement);
 
@@ -147,7 +147,7 @@ const getElementTopCoordinateAtLeftAndRightPosition = (alignment, triggerRect, e
   }
 };
 
-const getViePort = () => ({
+const getViewPort = () => ({
   height: window.visualViewport?.height || window.innerHeight || document.documentElement.clientHeight,
   width: window.visualViewport?.width || window.innerWidth || document.documentElement.clientWidth,
 });
@@ -571,36 +571,36 @@ const touchCollocateElemeAt = (element, elementContent, trigger, arrow) => {
     arrowRect: arrow,
     contentExtraHeight: getElementContentExtraHeight(elementContent, elementRect.height),
   };
-  const touchScreensElementCoordinates = mapCoordinatesToCenterPosition(rect, getViePort());
+  const touchScreensElementCoordinates = mapCoordinatesToCenterPosition(rect, getViewPort());
   applyTouchScreensCoordinates(element, elementContent, { ...touchScreensElementCoordinates });
 };
 
-/* New version of IOS does not trigger any event when the vieport changes due to soft keyboar
+/* New version of IOS does not trigger any event when the viewport changes due to soft keyboar
  * so we need to use an interval to detect changes.
- * onVieportChangeInterval should be dismissed when the dorpdown is closed */
-const touchDetectVieportChangesAndCollocate = (element, elementContent, trigger, arrow) => {
-  const getState = () => ({
+ * onViewportChangeInterval should be dismissed when the dorpdown is closed */
+const touchDetectViewportChangesAndCollocate = (element, elementContent, trigger, arrow) => {
+  const getWindowDimensions = () => ({
     winHeight: window.innerHeight,
     visualHeight: window.visualViewport?.height || 0,
     visualOffsetTop: window.visualViewport?.offsetTop || 0,
   });
-  const isSameEstate = (e1, e2) => (
-    e1.winHeight === e2.winHeight
-    && e1.visualHeight === e2.visualHeight
-    && e1.visualOffsetTop === e2.visualOffsetTop
+  const areDimesionsEqual = (w1, w2) => (
+    w1.winHeight === w2.winHeight
+    && w1.visualHeight === w2.visualHeight
+    && w1.visualOffsetTop === w2.visualOffsetTop
   );
 
-  let previousState = getState();
-  const resizeOnVieportChange = () => {
-    const state = getState();
-    if (!isSameEstate(previousState, state)) {
-      previousState = state;
+  let previousWindowsDimensions = getWindowDimensions();
+  const resizeOnViewportChange = () => {
+    const currentWindowsDimensions = getWindowDimensions();
+    if (!areDimesionsEqual(previousWindowsDimensions, currentWindowsDimensions)) {
+      previousWindowsDimensions = currentWindowsDimensions;
       touchCollocateElemeAt(element, elementContent, trigger, arrow, 0);
     }
   };
 
   touchCollocateElemeAt(element, elementContent, trigger, arrow);
-  element.onVieportChangeInterval = setInterval(resizeOnVieportChange, onVieportChangeIntervalMs);
+  element.onViewportChangeInterval = setInterval(resizeOnViewportChange, onViewportChangeIntervalInMs);
 };
 
 const collocateElementAt = ({
@@ -611,7 +611,7 @@ const collocateElementAt = ({
 } = {}, offset = 0, askedCollocation, availableCollocations) => {
   if (!element || !trigger) { return false; }
   if (hasTouchSupport) {
-    touchDetectVieportChangesAndCollocate(element, elementContent, trigger, arrow);
+    touchDetectViewportChangesAndCollocate(element, elementContent, trigger, arrow);
     return true;
   }
   resetElementContentHeight(elementContent);
@@ -623,7 +623,7 @@ const collocateElementAt = ({
     arrowRect: arrow,
     contentExtraHeight: getElementContentExtraHeight(elementContent, elementRect.height),
   };
-  const viewport = getViePort();
+  const viewport = getViewPort();
   const collocationWithCoordinates = getCollocationWithCoordinates(rect, offset, askedCollocation, availableCollocations, viewport);
   if (!collocationWithCoordinates) { return false; }
   applyCoordinates(element, arrow, elementContent, collocationWithCoordinates.coordinates, viewport);

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -15,7 +15,7 @@ const allAvailableCollocations = [
 
 const maxThresholdInPixels = 20;
 
-const touchDeviceThresholdInPixels = 10;
+const maxTouchThresholdInPixels = 10;
 
 const maxThresholdInPercentage = 5;
 
@@ -590,23 +590,23 @@ const applyTouchElementCentering = (element) => {
   element.style.marginTop = `-${negativeMarginY}px`;
 
   const left = window.scrollX + (viewport.width / 2);
-  const maxAvailableViewportWidth = viewport.width - (touchDeviceThresholdInPixels * 2);
+  const maxAvailableViewportWidth = viewport.width - (maxTouchThresholdInPixels * 2);
   const negativeMarginX = elementRect.width / 2;
   element.style.left = `${left}px`;
   element.style.width = `${maxAvailableViewportWidth}px`;
   element.style.marginLeft = `-${negativeMarginX}px`;
 };
 
-const applyInitialTouchElementStyle = (element) => {
+const applyTouchElementStyle = (element) => {
   const initialMaxDropdownHeight = getElementComputedMaxHeight(element);
   const initialMaxDropdownWidth = getElementComputedMaxWidth(element);
   const viewport = getViewPort();
 
-  const maxAvailableViewportHeight = viewport.height - (touchDeviceThresholdInPixels * 2);
+  const maxAvailableViewportHeight = viewport.height - (maxTouchThresholdInPixels * 2);
   const maxAvailableHeight = Math.min(maxAvailableViewportHeight, initialMaxDropdownHeight);
   element.style.maxHeight = `${maxAvailableHeight}px`;
 
-  const maxAvailableViewportWidth = viewport.width - (touchDeviceThresholdInPixels * 2);
+  const maxAvailableViewportWidth = viewport.width - (maxTouchThresholdInPixels * 2);
   const maxAvailableWidth = Math.min(maxAvailableViewportWidth, initialMaxDropdownWidth, maxTouchElementWidthInPixels);
   element.style.maxWidth = `${maxAvailableWidth}px`;
 
@@ -614,7 +614,7 @@ const applyInitialTouchElementStyle = (element) => {
 };
 
 const touchCollocateElemeAt = (element, elementContent) => {
-  applyTouchElementCentering(element);
+  applyTouchElementStyle(element);
   resetElementContentMaxHeight(elementContent);
   setTimeout(() => {
     applyTouchElementContentMaxHeight(element, elementContent);
@@ -658,7 +658,7 @@ const touchDetectViewportChangesAndCollocate = (element, elementContent, trigger
       touchCollocateElemeAt(element, elementContent, trigger, arrow, 0);
     }
   };
-  applyInitialTouchElementStyle(element);
+  applyTouchElementStyle(element);
   touchCollocateElemeAt(element, elementContent, trigger, arrow);
 
   /* Interval reference stored in dom element can't be used to clear the interval


### PR DESCRIPTION
### Task

* [Modal redesign](https://digitalcrew.teamwork.com/#/tasks/19658030)
* [Create a ticket > Customer dropdown is not behaving properly](https://digitalcrew.teamwork.com/#/projects/364255/tasks/18821341)

**DO NOT MERGE until this has been tested integrated into deskclient https://github.com/Teamwork/deskclient/pull/5307  and package version has been bumped to non beta**


### Description

This PR fixes some issues with the dropdown area being hidden behind the software keyboard and not accessible, especially in IOS safari. 

More info about the problem here:
* https://blog.opendigerati.com/the-eccentric-ways-of-ios-safari-with-the-keyboard-b5aa3f34228d
* https://developpaper.com/ios-keyboard-puzzle-and-visual-view-port-api/

Other features:
* Adds a close button when the dropdown is full screen so user can close easily
* Can pass a class when initialising the dropdown on which touch scrolling gets prevented. this is to solve issues when the dropdown is opened and the user scrolls the page.

### Implementation details.

To fix this issue an interval is created **while the dropdown is opened (only while it is opened)** to listen to some changes in the visualViewport,  scrollPosition and page height, IOS does not have any event listeners for some of these properties so we need to use an interval. 

**Before**

https://user-images.githubusercontent.com/2648215/154648804-c6237102-30b9-4faf-a522-7b16d1a39766.mp4


**After**

https://user-images.githubusercontent.com/2648215/154648793-2f3e8af7-8b11-4a7e-bcf8-0b4d8b039fa5.mp4




[Safari is the new IE !!!](https://www.reddit.com/r/programming/comments/n6a5v8/safari_is_the_new_internet_explorer_i_thought/)

