### PR TITLE
20160800 bugfix touch screen closing dropdown due to click event trigguered during open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.1-beta.3",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.1-beta.2",
+  "version": "2.5.1-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.1-beta.1",
+  "version": "2.5.1-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0",
+  "version": "2.5.1-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.0",
+  "version": "2.5.1-beta.1",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.1-beta.2",
+  "version": "2.5.1-beta.3",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.1-beta.1",
+  "version": "2.5.1-beta.2",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "2.5.1-beta.3",
+  "version": "2.5.1",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/src/Dropdown.directive.js
+++ b/src/Dropdown.directive.js
@@ -165,7 +165,7 @@ const openDropdown = ({
   // timeout fixes a bug where same open click event triggers the closeDropdown event
   setTimeout(() => {
     attachListeners(temporaryHideAllDropdownsRef);
-  }, 0);
+  }, 200);
   onOpen?.();
 };
 

--- a/src/Dropdown.directive.js
+++ b/src/Dropdown.directive.js
@@ -162,7 +162,10 @@ const openDropdown = ({
     trigger.click?.();
     return;
   }
-  attachListeners(temporaryHideAllDropdownsRef);
+  // timeout fixes a bug where same open click event triggers the closeDropdown event
+  setTimeout(() => {
+    attachListeners(temporaryHideAllDropdownsRef);
+  }, 0);
   onOpen?.();
 };
 


### PR DESCRIPTION
### Task

* [Dropdown not opening in mobile after user clicks in the dropdown, only after user starts to type](https://digitalcrew.teamwork.com/app/tasks/20160800)
* [Associated DeskClient PR](https://github.com/Teamwork/deskclient/pull/5787)


**Notes:** In touch devices there is some event triggered in the body by the same click that opens dropdown, therefore forcing the dropdown to immediately close (outside dropdown close listener). The source of this event can NOT be identified and the next solution is to delay attaching the close dropdown listener to next javascript event loop. 

**Please dont merged until is tested in [associated desk client PR](https://github.com/Teamwork/deskclient/pull/5787) and beta version is bumped**