### PR TITLE
leave height auto to shrink when necessary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/src/collocateElement.utility.js
+++ b/src/collocateElement.utility.js
@@ -498,13 +498,14 @@ const applyCoordinatesToElement = (element, coordinates) => {
 
 const applyOverflowToElementContent = (element, height) => {
   if (!element || !element.style || !height) { return; }
-  element.style.height = `${height}px`;
+  element.style.maxHeight = `${height}px`;
   element.style.overflowY = 'auto';
 };
 
 const resetElementHeight = (element) => {
   if (!element || !element.style) { return; }
   element.style.height = 'auto';
+  element.style.maxHeight = 'auto';
 };
 
 const resetElementMaxHeight = (element) => {


### PR DESCRIPTION
Use `max-height` on overflowing container so height `auto` can still shrink when necessary space is decreased,

### Before
![unpog](https://github.com/user-attachments/assets/b948c8fe-50a2-4f10-a0b6-f4954ea2e31a)


### After
![pog](https://github.com/user-attachments/assets/75b14d34-d081-4bec-a168-d1249acf2368)
