### PR TITLE
Bugfix prevent dropdown to close when scroll event inside the dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamwork/vue-dropdown-directive",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamwork/vue-dropdown-directive",
-      "version": "3.0.1",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamwork/vue-dropdown-directive",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A vue.js directive for handling dropdowns",
   "author": "Mattia Uggè (matcmd) <mattia.ugge@teamwork.com>",
   "scripts": {

--- a/src/Dropdown.directive.js
+++ b/src/Dropdown.directive.js
@@ -67,7 +67,7 @@ const temporaryHideAllDropdowns = (
   dropdownId,
 ) => {
   const eventParentIds = event?.path?.map(({ id }) => id) || [];
-  const isEventFromInsideDropdown = eventParentIds.includes(dropdownId) || !!event.target.closest(".dropdown");
+  const isEventFromInsideDropdown = eventParentIds.includes(dropdownId) || !!event.target.closest('[dropdown-id]');
   const isScrollEvent = event.type === 'scroll';
   const shouldIgnoreEvent = isEventFromInsideDropdown && isScrollEvent;
   if (shouldIgnoreEvent) { return; } // prevents scroll events from inside dropdown hiding dropdowns https://github.com/Teamwork/deskclient/pull/3600#issue-613566610

--- a/src/Dropdown.directive.js
+++ b/src/Dropdown.directive.js
@@ -67,7 +67,7 @@ const temporaryHideAllDropdowns = (
   dropdownId,
 ) => {
   const eventParentIds = event?.path?.map(({ id }) => id) || [];
-  const isEventFromInsideDropdown = eventParentIds.includes(dropdownId);
+  const isEventFromInsideDropdown = eventParentIds.includes(dropdownId) || !!event.target.closest(".dropdown");
   const isScrollEvent = event.type === 'scroll';
   const shouldIgnoreEvent = isEventFromInsideDropdown && isScrollEvent;
   if (shouldIgnoreEvent) { return; } // prevents scroll events from inside dropdown hiding dropdowns https://github.com/Teamwork/deskclient/pull/3600#issue-613566610


### PR DESCRIPTION
After applying new Ligth-Speed styles to desk ui the dropdowns are closing after inputs trigger an scroll event that is detected like being from outside the dropdown. so fixing this issue.

This will be applied only to the remove old UI code branch. https://github.com/Teamwork/deskclient/pull/6786

[dropdown-bug.webm](https://github.com/user-attachments/assets/b2256220-f7f5-43fd-997b-d4a6c25f6661)
